### PR TITLE
feat(fe): make admin key input for SignUp

### DIFF
--- a/frontend/app/(auth)/signup/page.tsx
+++ b/frontend/app/(auth)/signup/page.tsx
@@ -10,6 +10,7 @@ type FormData = {
     email: string;
     password: string;
     role: string;
+    adminSecret?: string;
 }
 export default function SignupPage() {
     const router = useRouter()
@@ -32,7 +33,12 @@ export default function SignupPage() {
                 'Content-Type': 'application/json',
             }
             if (isAdmin) {
-                headers['x-admin-secret'] = process.env.NEXT_PUBLIC_ADMIN_SECRET!
+                // headers['x-admin-secret'] = process.env.NEXT_PUBLIC_ADMIN_SECRET!
+                if (data.adminSecret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+                    setError('잘못된 관리자 비밀키입니다.')
+                    return
+                }
+                headers['x-admin-secret'] = data.adminSecret!
             }
             const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/users/signup`, {
                 method: 'POST',
@@ -100,6 +106,18 @@ export default function SignupPage() {
                 />
                 {errors.password && <p className="text-red-500 text-sm mt-1">{errors.password.message}</p>}
             </div>
+            {isAdmin && (
+                <div>
+                <label className="block text-sm">관리자 비밀키</label>
+                <input
+                    type="password"
+                    {...register('adminSecret', { required: '관리자 비밀키를 입력하세요' })}
+                    className="w-full border p-2 rounded mt-1"
+                    placeholder="관리자 비밀키를 입력하세요"
+                />
+                {errors.adminSecret && <p className="text-red-500 text-sm mt-1">{errors.adminSecret.message}</p>}
+                </div>
+            )}
 
             <button
                 type="submit"


### PR DESCRIPTION
admin 페이지의 adminkey 를 구현하였습니다.
나중에 키가 바뀐다면 .env만 고치면 됩니다.

![image](https://github.com/user-attachments/assets/351efae0-694d-45a4-b73a-e49f0c94f722)
<img width="326" alt="image" src="https://github.com/user-attachments/assets/c9629f5f-d5ca-4663-a108-ce7476708bdc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Signup form now includes an input for "관리자 비밀키" (admin secret key) when registering as an admin.
- **Bug Fixes**
  - Improved validation: Admin secret key is now checked on the client side, displaying an error message if the key is incorrect before submitting the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->