### PR TITLE
feat(be): grant host reservation deletion previlege

### DIFF
--- a/api-testing/ReservationV2/Host Cancel Reservation V2.bru
+++ b/api-testing/ReservationV2/Host Cancel Reservation V2.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Host Cancel Reservation V2
+  type: http
+  seq: 22
+}
+
+delete {
+  url: {{Url}}/v2/reservations/1
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Cancel Reservation V2
+  기존 예약을 취소합니다. 본인이 만든 부스에 대한 예약만 취소 가능.
+}

--- a/backend/src/main/java/com/skkutable/controller/ReservationControllerV2.java
+++ b/backend/src/main/java/com/skkutable/controller/ReservationControllerV2.java
@@ -41,8 +41,7 @@ public class ReservationControllerV2 {
   //에약 수정 (USER/HOST/ADMIN - 본인 예약만)
   @PatchMapping("/{reservationId}")
   @PreAuthorize("isAuthenticated()")
-  public ResponseEntity<ReservationResponseDTO> updateReservation(
-      @PathVariable Long reservationId,
+  public ResponseEntity<ReservationResponseDTO> updateReservation(@PathVariable Long reservationId,
       @Valid @RequestBody ReservationRequestDTO dto,
       @AuthenticationPrincipal(expression = "username") String email) {
     ReservationResponseDTO response = reservationService.updateReservation(reservationId, dto,
@@ -50,7 +49,8 @@ public class ReservationControllerV2 {
     return ResponseEntity.ok(response);
   }
 
-  // 예약 취소 (USER/HOST/ADMIN - 본인 예약만)
+  // 예약 취소 (USER 본인 예약만)
+  // HOST와 ADMIN은 본인이 만든 부스에 대해 예약 취소 권한이 있음
   @DeleteMapping("/{reservationId}")
   @PreAuthorize("isAuthenticated()")
   public ResponseEntity<Void> cancelReservation(@PathVariable Long reservationId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new API test for host-initiated reservation cancellation.

- **Bug Fixes**
  - Improved authorization rules for reservation cancellation: users can only cancel their own reservations, while hosts and admins can cancel reservations for booths they created. Unauthorized cancellations are now properly restricted.

- **Documentation**
  - Updated comments to clarify reservation cancellation permissions for different user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->